### PR TITLE
Team roster

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,34 @@ A Ruby wrapper around the completely undocumented stats.nba.com API
 Based on internet consensus, the NBA allows developers to retrieve data from their APIs, but they provide zero hand-holding (aka there is no known documentation on how to use the API). I hope to create a wrapper that is both easy to use and heavily documented (to make it even easier to use). For the time being, I will continue to poke around and see what kind of progress I can make by starting off small and gradually adding on more and more capabilities.
 
 More. will. come.
+
+## Documentation
+
+I am writing this documentation before I write any of the actual code. Why? Because I want this wrapper to be easy to use and have it feel natural when working with it. Some of what is listed in here will not yet be implemented.
+
+### Running List of Ideas
+
+Team.knicks.roster
+Team.knicks.stats
+Team.knicks.player_stats
+
+and/or
+
+Team('knicks').roster
+Team('knicks').stats
+Team('knicks').player_stats
+
+Player('steph curry').team
+Player('steph curry').stats
+Player('steph curry').info
+
+College('unc').players
+
+Game('knicks').vs('sixers')
+Game('knicks').home
+Game('knicks').away
+
+League.leaders
+League.standings
+League('east').teams
+League('west').standings

--- a/lib/nba_stats.rb
+++ b/lib/nba_stats.rb
@@ -1,0 +1,15 @@
+require 'json'
+require 'rest-client'
+require './lib/team'
+
+module NBAStats
+  BASE_URL = 'http://stats.nba.com/stats/'
+  CURRENT_SEASON = '2018-19'
+  REQUEST_HEADERS = {
+    'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/45.0.2454.101 Safari/537.36',
+    'Dnt': '1',
+    'Accept-Encoding': 'gzip, deflate, sdch',
+    'Accept-Language': 'en',
+    'origin': 'http://stats.nba.com'
+  }
+end

--- a/lib/team.rb
+++ b/lib/team.rb
@@ -1,12 +1,138 @@
 module NBAStats
   module Team
+    def self.bucks
+      Team.new(1610612749)
+    end
+
+    def self.bulls
+      Team.new(1610612741)
+    end
+
+    def self.cavaliers
+      Team.new(1610612739)
+    end
+
+    def self.celtics
+      Team.new(1610612738)
+    end
+
+    def self.clippers
+      Team.new(1610612746)
+    end
+
+    def self.grizzlies
+      Team.new(1610612763)
+    end
+
+    def self.hawks
+      Team.new(1610612737)
+    end
+
+    def self.heat
+      Team.new(1610612748)
+    end
+
+    def self.hornets
+      Team.new(1610612766)
+    end
+
+    def self.jazz
+      Team.new(1610612762)
+    end
+
+    def self.kings
+      Team.new(1610612758)
+    end
+
+    def self.knicks
+      Team.new(1610612752)
+    end
+
+    def self.lakers
+      Team.new(1610612747)
+    end
+
+    def self.magic
+      Team.new(1610612753)
+    end
+
+    def self.mavericks
+      Team.new(1610612742)
+    end
+
+    def self.nets
+      Team.new(1610612751)
+    end
+
+    def self.nuggets
+      Team.new(1610612743)
+    end
+
+    def self.pacers
+      Team.new(1610612754)
+    end
+
+    def self.pelicans
+      Team.new(1610612740)
+    end
+
+    def self.pistons
+      Team.new(1610612765)
+    end
+
+    def self.raptors
+      Team.new(1610612761)
+    end
+
+    def self.rockets
+      Team.new(1610612745)
+    end
+
+    def self.sixers
+      Team.new(1610612755)
+    end
+
+    def self.spurs
+      Team.new(1610612759)
+    end
+
+    def self.suns
+      Team.new(1610612756)
+    end
+
+    def self.thunder
+      Team.new(1610612760)
+    end
+
+    def self.timberwolves
+      Team.new(1610612750)
+    end
+
+    def self.trailblazers
+      Team.new(1610612757)
+    end
+
+    def self.warriors
+      Team.new(1610612744)
+    end
+
+    def self.wizards
+      Team.new(1610612764)
+    end
+
+    class Team
+      attr_reader :roster
+
+      def initialize(team_id)
+        @roster = Roster.new(team_id)
+      end
+    end
+
     class Roster
       attr_reader :coaches, :players
 
-      def initialize(*args)
-        super(*args)
-
-        response = JSON.parse(RestClient.get('stats.nba.com/stats/commonteamroster/?LeagueID=00&TeamID=1610612752&Season=2018-19', NBAStats::REQUEST_HEADERS))
+      def initialize(team_id)
+        response = JSON.parse(RestClient.get("stats.nba.com/stats/commonteamroster/?LeagueID=00&TeamID=#{team_id}&Season=2018-19", NBAStats::REQUEST_HEADERS))
         @coaches = response['resultSets'][1]['rowSet'].map { |coach| coach[5] }
         @players = response['resultSets'][0]['rowSet'].map { |player| player[3] }
       end

--- a/lib/team.rb
+++ b/lib/team.rb
@@ -1,0 +1,15 @@
+module NBAStats
+  module Team
+    class Roster
+      attr_reader :coaches, :players
+
+      def initialize(*args)
+        super(*args)
+
+        response = JSON.parse(RestClient.get('stats.nba.com/stats/commonteamroster/?LeagueID=00&TeamID=1610612752&Season=2018-19', NBAStats::REQUEST_HEADERS))
+        @coaches = response['resultSets'][1]['rowSet'].map { |coach| coach[5] }
+        @players = response['resultSets'][0]['rowSet'].map { |player| player[3] }
+      end
+    end
+  end
+end

--- a/playground.rb
+++ b/playground.rb
@@ -1,7 +1,7 @@
-# a place to try things with the API and/or wrapper
+# a place to try things
 
 require './lib/nba_stats'
 
-knicks_roster = NBAStats::Team::Roster.new()
+knicks_roster = NBAStats::Team.knicks.roster
 puts "players: #{knicks_roster.players}"
 puts "coaches: #{knicks_roster.coaches}"

--- a/playground.rb
+++ b/playground.rb
@@ -1,0 +1,7 @@
+# a place to try things with the API and/or wrapper
+
+require './lib/nba_stats'
+
+knicks_roster = NBAStats::Team::Roster.new()
+puts "players: #{knicks_roster.players}"
+puts "coaches: #{knicks_roster.coaches}"


### PR DESCRIPTION
Add team roster support for all teams.

Examples:
```
NBAStats::Team.knicks.roster.players
NBAStats::Team.magic.roster
NBAStats::Team.pelicans.roster.coaches
NBAStats::Team.raptors.roster
```

Documentation will follow, but it's essentially `NBAStats::Team.<teamname>.roster` where team name is the name without the city, all lower case, no separators.